### PR TITLE
Add PostgreSQL deployment with pgvector

### DIFF
--- a/deploy/07-deploy-postgresql.sh
+++ b/deploy/07-deploy-postgresql.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Deploy PostgreSQL with pgvector to Kubernetes
+# Requires: kubectl configured with cluster access
+#
+# Required environment variables:
+#   POSTGRES_USER     - Database superuser name
+#   POSTGRES_PASSWORD - Database superuser password
+#   POSTGRES_DB       - Default database name
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KUBE_DIR="$SCRIPT_DIR/../kube/postgresql"
+
+# Check required environment variables
+if [ -z "$POSTGRES_USER" ] || [ -z "$POSTGRES_PASSWORD" ] || [ -z "$POSTGRES_DB" ]; then
+    echo "ERROR: Required environment variables not set."
+    echo ""
+    echo "Please set the following before running:"
+    echo "  export POSTGRES_USER=postgres"
+    echo "  export POSTGRES_PASSWORD=your_secure_password"
+    echo "  export POSTGRES_DB=homelab"
+    exit 1
+fi
+
+echo "=== Deploying PostgreSQL ==="
+
+# Apply namespace first
+echo "Creating namespace..."
+kubectl apply -f "$KUBE_DIR/postgresql-namespace.yaml"
+
+# Apply secret with environment variable substitution
+echo "Applying credentials secret..."
+envsubst < "$KUBE_DIR/postgresql-secret.yaml" | kubectl apply -f -
+
+# Apply PVC
+echo "Creating persistent volume claim..."
+kubectl apply -f "$KUBE_DIR/postgresql-pvc.yaml"
+
+# Apply StatefulSet
+echo "Deploying StatefulSet..."
+kubectl apply -f "$KUBE_DIR/postgresql-statefulset.yaml"
+
+# Apply Service
+echo "Creating LoadBalancer service..."
+kubectl apply -f "$KUBE_DIR/postgresql-service.yaml"
+
+echo ""
+echo "=== Waiting for pod to be ready ==="
+kubectl wait --for=condition=ready pod -l app=postgresql -n postgresql --timeout=120s
+
+echo ""
+echo "=== PostgreSQL deployment complete ==="
+echo ""
+echo "Service details:"
+kubectl get svc postgresql -n postgresql
+echo ""
+echo "To connect: psql -h <EXTERNAL-IP> -U $POSTGRES_USER -d $POSTGRES_DB"
+echo ""
+echo "To enable pgvector extension, run:"
+echo "  CREATE EXTENSION vector;"

--- a/kube/postgresql/postgresql-namespace.yaml
+++ b/kube/postgresql/postgresql-namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: postgresql
+  labels:
+    app: postgresql
+    app.kubernetes.io/name: postgresql

--- a/kube/postgresql/postgresql-pvc.yaml
+++ b/kube/postgresql/postgresql-pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgresql-data
+  namespace: postgresql
+  labels:
+    app: postgresql
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: managed-nfs-storage
+  resources:
+    requests:
+      storage: 10Gi

--- a/kube/postgresql/postgresql-secret.yaml
+++ b/kube/postgresql/postgresql-secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-credentials
+  namespace: postgresql
+type: Opaque
+stringData:
+  POSTGRES_USER: "${POSTGRES_USER}"
+  POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+  POSTGRES_DB: "${POSTGRES_DB}"

--- a/kube/postgresql/postgresql-service.yaml
+++ b/kube/postgresql/postgresql-service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+  namespace: postgresql
+  labels:
+    app: postgresql
+spec:
+  type: LoadBalancer
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: 5432
+      protocol: TCP
+  selector:
+    app: postgresql

--- a/kube/postgresql/postgresql-statefulset.yaml
+++ b/kube/postgresql/postgresql-statefulset.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgresql
+  namespace: postgresql
+  labels:
+    app: postgresql
+spec:
+  serviceName: postgresql
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgresql
+  template:
+    metadata:
+      labels:
+        app: postgresql
+    spec:
+      containers:
+        - name: postgresql
+          image: pgvector/pgvector:pg17
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5432
+              name: postgresql
+          envFrom:
+            - secretRef:
+                name: postgresql-credentials
+          env:
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+          volumeMounts:
+            - name: postgresql-data
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - postgres
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - postgres
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+      volumes:
+        - name: postgresql-data
+          persistentVolumeClaim:
+            claimName: postgresql-data


### PR DESCRIPTION
## Summary
- Add PostgreSQL 17 with pgvector extension for AI/embedding workloads
- Use existing NFS storage on Synology NAS via `managed-nfs-storage` StorageClass
- Expose via LoadBalancer (MetalLB) for external access
- Environment variable substitution for secure credential management

## Files Added
- `kube/postgresql/` - Kubernetes manifests (namespace, PVC, StatefulSet, service, secret template)
- `deploy/07-deploy-postgresql.sh` - Deploy script with env var validation

## Test plan
- [x] Deployed to cluster successfully
- [x] Pod running: `kubectl get pods -n postgresql`
- [x] LoadBalancer IP assigned: `192.168.0.203`
- [x] Verify pgvector extension: `CREATE EXTENSION vector;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)