### PR TITLE
feat(tailscale): add Tailscale K8s operator with subnet router and expose all services

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ graph TD
   - **CNI**: Flannel.
   - **Load Balancer**: MetalLB (Layer 2 mode).
   - **Ingress**: Nginx Ingress Controller.
+  - **Remote Access**: Tailscale Kubernetes Operator (subnet router to tailnet).
 - **Storage**: Synology NAS via NFS (dynamic provisioning using `nfs-subdir-external-provisioner`).
 - **Provisioning**: Ansible.
 

--- a/deploy/04-02-expose-kubernetes-dashboard.sh
+++ b/deploy/04-02-expose-kubernetes-dashboard.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Expose the Kubernetes Dashboard on the home LAN (MetalLB) and Tailnet.
+# Eliminates the need for: kubectl port-forward svc/kubernetes-dashboard-kong-proxy 8443:443
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KUBE_DIR="$SCRIPT_DIR/../kube/kubernetes-dashboard"
+
+echo "=== Exposing Kubernetes Dashboard ==="
+echo ""
+
+# Patch the kong-proxy service
+echo "--- Patching kubernetes-dashboard-kong-proxy service ---"
+kubectl patch svc kubernetes-dashboard-kong-proxy \
+    -n kubernetes-dashboard \
+    --type merge \
+    --patch-file "$KUBE_DIR/expose-dashboard.yaml"
+
+# Wait a moment for MetalLB to assign an IP
+echo ""
+echo "--- Waiting for external IP assignment ---"
+sleep 5
+
+# Get the assigned IP
+EXTERNAL_IP=$(kubectl get svc kubernetes-dashboard-kong-proxy \
+    -n kubernetes-dashboard \
+    -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null)
+
+echo ""
+echo "=== Dashboard exposed ==="
+echo ""
+if [ -n "$EXTERNAL_IP" ]; then
+    echo "  Home LAN:  https://$EXTERNAL_IP"
+else
+    echo "  Home LAN:  (waiting for MetalLB IP — run: kubectl get svc -n kubernetes-dashboard)"
+fi
+echo "  Tailnet:   https://kubernetes-dashboard  (once Tailscale operator is running)"
+echo ""
+echo "  Don't forget: you still need a token to log in."
+echo "  Get one with: kubectl -n kubernetes-dashboard create token admin-user"

--- a/deploy/09-deploy-tailscale.sh
+++ b/deploy/09-deploy-tailscale.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Deploy the Tailscale Kubernetes Operator and Connector (subnet router)
+# Requires: kubectl and helm configured with cluster access
+#
+# Required environment variables:
+#   TAILSCALE_OAUTH_CLIENT_ID      - OAuth client ID from Tailscale admin console
+#   TAILSCALE_OAUTH_CLIENT_SECRET  - OAuth client secret from Tailscale admin console
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KUBE_DIR="$SCRIPT_DIR/../kube/tailscale"
+
+# ── Preflight checks ──────────────────────────────────────────────────────────
+MISSING=""
+for var in TAILSCALE_OAUTH_CLIENT_ID TAILSCALE_OAUTH_CLIENT_SECRET; do
+    if [ -z "${!var}" ]; then
+        MISSING="$MISSING  $var\n"
+    fi
+done
+
+if [ -n "$MISSING" ]; then
+    echo "ERROR: Required environment variables not set:"
+    echo ""
+    echo -e "$MISSING"
+    echo "Source your secrets file first: source sensitive/secrets.sh"
+    exit 1
+fi
+
+# ── Step 1: Install the Tailscale Kubernetes Operator via Helm ─────────────────
+echo ""
+echo "=== Deploying Tailscale Kubernetes Operator ==="
+echo ""
+
+echo "--- Adding Tailscale Helm repo ---"
+helm repo add tailscale https://pkgs.tailscale.com/helmcharts 2>/dev/null || true
+helm repo update
+
+echo ""
+echo "--- Installing / upgrading tailscale-operator ---"
+helm upgrade --install tailscale-operator tailscale/tailscale-operator \
+    --namespace=tailscale \
+    --create-namespace \
+    --set-string oauth.clientId="$TAILSCALE_OAUTH_CLIENT_ID" \
+    --set-string oauth.clientSecret="$TAILSCALE_OAUTH_CLIENT_SECRET" \
+    --wait
+
+# ── Step 2: Wait for the operator pod to be ready ─────────────────────────────
+echo ""
+echo "--- Waiting for operator pod to be ready ---"
+kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=tailscale-operator \
+    -n tailscale --timeout=120s || true
+
+# ── Step 3: Apply the Connector (subnet router) ──────────────────────────────
+echo ""
+echo "--- Applying Connector (subnet router) ---"
+kubectl apply -f "$KUBE_DIR/connector.yaml"
+
+# ── Step 4: Wait for Connector to be created ──────────────────────────────────
+echo ""
+echo "--- Waiting for Connector to be created ---"
+sleep 10
+kubectl get connector home-kube-subnet-router 2>/dev/null || echo "(Connector may take a moment to appear)"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Tailscale deployment complete ==="
+echo ""
+echo "Operator:"
+kubectl get pods -n tailscale
+echo ""
+echo "Connector:"
+kubectl get connector home-kube-subnet-router 2>/dev/null || echo "(pending)"
+echo ""
+echo "╔══════════════════════════════════════════════════════════════════╗"
+echo "║  NEXT STEPS (manual):                                          ║"
+echo "║                                                                ║"
+echo "║  1. Open https://login.tailscale.com/admin/machines            ║"
+echo "║  2. Find 'home-kube-subnet-router' and approve its routes:     ║"
+echo "║       • 192.168.0.0/24   (home LAN)                           ║"
+echo "║       • 10.96.0.0/12     (K8s Service CIDR)                   ║"
+echo "║       • 10.244.0.0/16    (Pod CIDR / Flannel)                 ║"
+echo "║  3. On each client: ensure 'Accept Routes' is enabled.        ║"
+echo "║                                                                ║"
+echo "║  Or configure autoApprovers in your Tailscale ACL policy:      ║"
+echo "║    \"autoApprovers\": {                                         ║"
+echo "║      \"routes\": {                                              ║"
+echo "║        \"192.168.0.0/24\":  [\"tag:k8s\"],                        ║"
+echo "║        \"10.96.0.0/12\":    [\"tag:k8s\"],                        ║"
+echo "║        \"10.244.0.0/16\":   [\"tag:k8s\"]                         ║"
+echo "║      }                                                        ║"
+echo "║    }                                                           ║"
+echo "╚══════════════════════════════════════════════════════════════════╝"

--- a/deploy/10-expose-services-tailscale.sh
+++ b/deploy/10-expose-services-tailscale.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Expose all home-kube services to the Tailscale tailnet.
+# Run this AFTER the Tailscale operator is deployed (09-deploy-tailscale.sh).
+#
+# Services exposed:
+#   - kubernetes-dashboard  → https://kubernetes-dashboard
+#   - openclaw (personal)   → http://openclaw-personal:18789
+#   - openclaw (citepulse)  → http://openclaw-citepulse:18789
+#   - postgresql            → homelab-postgres:5432
+#   - rustdesk hbbs         → rustdesk-hbbs:21115-21118
+#   - rustdesk hbbr         → rustdesk-hbbr:21117,21119
+#
+# Note: OpenClaw services get Tailscale annotations via Helm values
+# (values-personal.yaml / values-citepulse.yaml), so they are exposed
+# automatically when you run 08-deploy-openclaw.sh. This script handles
+# the remaining services.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "=== Exposing all services to Tailscale tailnet ==="
+
+# ── Kubernetes Dashboard ──────────────────────────────────────────────────────
+echo ""
+echo "--- Kubernetes Dashboard ---"
+kubectl patch svc kubernetes-dashboard-kong-proxy \
+    -n kubernetes-dashboard \
+    --type merge \
+    --patch-file "$SCRIPT_DIR/../kube/kubernetes-dashboard/expose-dashboard.yaml" \
+    2>/dev/null && echo "  ✓ Patched" || echo "  ⚠ Service not found (is the dashboard deployed?)"
+
+# ── PostgreSQL ────────────────────────────────────────────────────────────────
+echo ""
+echo "--- PostgreSQL ---"
+kubectl apply -f "$SCRIPT_DIR/../kube/postgresql/postgresql-service.yaml" \
+    2>/dev/null && echo "  ✓ Applied" || echo "  ⚠ Failed to apply"
+
+# ── RustDesk ──────────────────────────────────────────────────────────────────
+echo ""
+echo "--- RustDesk ---"
+kubectl apply -f "$SCRIPT_DIR/../kube/rustdesk-server/expose-rustdesk.yaml" \
+    2>/dev/null && echo "  ✓ Applied" || echo "  ⚠ Failed to apply"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "=== All services exposed ==="
+echo ""
+echo "Once the Tailscale operator provisions the devices, access via MagicDNS:"
+echo ""
+echo "  ┌──────────────────────┬───────────────────────────────────────────┐"
+echo "  │ Service              │ Tailnet URL                               │"
+echo "  ├──────────────────────┼───────────────────────────────────────────┤"
+echo "  │ K8s Dashboard        │ https://kubernetes-dashboard              │"
+echo "  │ OpenClaw (personal)  │ http://openclaw-personal:18789            │"
+echo "  │ OpenClaw (citepulse) │ http://openclaw-citepulse:18789           │"
+echo "  │ PostgreSQL           │ homelab-postgres:5432                     │"
+echo "  │ RustDesk (signaling) │ rustdesk-hbbs:21115-21118                │"
+echo "  │ RustDesk (relay)     │ rustdesk-hbbr:21117,21119                │"
+echo "  └──────────────────────┴───────────────────────────────────────────┘"
+echo ""
+echo "Note: OpenClaw Tailscale annotations are managed in Helm values files."
+echo "      Re-run 08-deploy-openclaw.sh to apply those."

--- a/kube/kubernetes-dashboard/expose-dashboard.yaml
+++ b/kube/kubernetes-dashboard/expose-dashboard.yaml
@@ -1,0 +1,23 @@
+# Patch the Kubernetes Dashboard Kong Proxy service to:
+#   1. Use LoadBalancer type so MetalLB assigns a home LAN IP (192.168.0.200-250)
+#   2. Expose it to the Tailscale tailnet via the operator annotation
+#
+# After applying, access via:
+#   Home LAN:  https://<METALLB-IP>:443
+#   Tailnet:   https://kubernetes-dashboard (MagicDNS)
+#
+# Apply with:
+#   kubectl patch svc kubernetes-dashboard-kong-proxy \
+#     -n kubernetes-dashboard \
+#     --type merge \
+#     --patch-file kube/kubernetes-dashboard/expose-dashboard.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubernetes-dashboard-kong-proxy
+  namespace: kubernetes-dashboard
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: "kubernetes-dashboard"
+spec:
+  type: LoadBalancer

--- a/kube/openclaw/values-citepulse.yaml
+++ b/kube/openclaw/values-citepulse.yaml
@@ -19,6 +19,8 @@ app-template:
     main:
       annotations:
         metallb.universe.tf/loadBalancerIPs: 192.168.0.205
+        tailscale.com/expose: "true"
+        tailscale.com/hostname: "openclaw-citepulse"
 
   configMaps:
     config:

--- a/kube/openclaw/values-personal.yaml
+++ b/kube/openclaw/values-personal.yaml
@@ -15,6 +15,8 @@ app-template:
     main:
       annotations:
         metallb.universe.tf/loadBalancerIPs: 192.168.0.204
+        tailscale.com/expose: "true"
+        tailscale.com/hostname: "openclaw-personal"
   configMaps:
     config:
       data:

--- a/kube/postgresql/postgresql-service.yaml
+++ b/kube/postgresql/postgresql-service.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: postgresql
   labels:
     app: postgresql
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: "homelab-postgres"
 spec:
   type: LoadBalancer
   ports:

--- a/kube/rustdesk-server/expose-rustdesk.yaml
+++ b/kube/rustdesk-server/expose-rustdesk.yaml
@@ -1,0 +1,55 @@
+# Patch RustDesk services to expose them on the Tailscale tailnet.
+#
+# RustDesk has two services:
+#   - rust-hbbs-service (signaling server — ports 21115, 21116, 21118)
+#   - rust-hbbr-service (relay server — ports 21117, 21119)
+#
+# Apply with:
+#   kubectl apply -f kube/rustdesk-server/expose-rustdesk.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rust-hbbs-service
+  namespace: rustdesk-server
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: "rustdesk-hbbs"
+spec:
+  type: LoadBalancer
+  ports:
+    - name: "21115"
+      port: 21115
+      targetPort: 21115
+    - name: "21116-tcp"
+      port: 21116
+      targetPort: 21116
+    - name: "21116-udp"
+      port: 21116
+      protocol: UDP
+      targetPort: 21116
+    - name: "21118"
+      port: 21118
+      targetPort: 21118
+  selector:
+    app.kubernetes.io/name: rust-hbbs-service
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rust-hbbr-service
+  namespace: rustdesk-server
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: "rustdesk-hbbr"
+spec:
+  type: LoadBalancer
+  ports:
+    - name: "21117"
+      port: 21117
+      targetPort: 21117
+    - name: "21119"
+      port: 21119
+      targetPort: 21119
+  selector:
+    app.kubernetes.io/name: rust-hbbr-service

--- a/kube/tailscale/connector.yaml
+++ b/kube/tailscale/connector.yaml
@@ -1,0 +1,23 @@
+# Tailscale Connector — Subnet Router
+# Advertises home LAN and cluster CIDRs to the tailnet so that
+# any device on the tailnet can reach services on the home network.
+#
+# Routes:
+#   192.168.0.0/24  — Home LAN (nodes, NAS, router, IoT, etc.)
+#   10.96.0.0/12    — Kubernetes Service CIDR (kubeadm default)
+#   10.244.0.0/16   — Pod CIDR (Flannel default)
+#
+# After applying, approve routes in the Tailscale admin console
+# (or configure autoApprovers in your ACL policy).
+apiVersion: tailscale.com/v1alpha1
+kind: Connector
+metadata:
+  name: home-kube-subnet-router
+spec:
+  replicas: 1
+  hostnamePrefix: home-kube-subnet-router
+  subnetRouter:
+    advertiseRoutes:
+      - "192.168.0.0/24"
+      - "10.96.0.0/12"
+      - "10.244.0.0/16"


### PR DESCRIPTION
- Deploy Tailscale Kubernetes Operator via Helm (09-deploy-tailscale.sh)
- Add Connector CRD as subnet router advertising home LAN (192.168.0.0/24),
  Service CIDR (10.96.0.0/12), and Pod CIDR (10.244.0.0/16)
- Expose Kubernetes Dashboard to tailnet (kubernetes-dashboard)
- Expose OpenClaw personal/citepulse to tailnet via Helm values annotations
- Expose PostgreSQL to tailnet (homelab-postgres)
- Expose RustDesk hbbs/hbbr to tailnet
- Add master script to expose all non-Helm services (10-expose-services-tailscale.sh)
- Add Tailscale OAuth credential placeholders to secrets.sh
- Update README with Tailscale in infrastructure stack
