### PR TITLE
feat(opencode): persist git credentials, SSH keys, and gh CLI auth across pod restarts

### DIFF
--- a/kube/opencode/values.yaml
+++ b/kube/opencode/values.yaml
@@ -79,10 +79,22 @@ app-template:
               fi
 
               # ── Global Git config ────────────────────────────────────
-              # ~/.gitconfig is on a persistent mount, so this only runs
-              # on first deploy. User can change these at runtime and
-              # they will survive pod restarts.
-              if [ ! -f /root/.gitconfig ]; then
+              # The PVC mounts a "dotfiles" directory. We symlink
+              # ~/.gitconfig into it so git config --global writes
+              # persist across pod restarts.
+              DOTFILES=/persistent-dotfiles
+              # Clean up the broken directory mount from the previous deploy
+              if [ -d /root/.gitconfig ] && [ ! -L /root/.gitconfig ]; then
+                log "Removing broken .gitconfig directory from previous mount"
+                rmdir /root/.gitconfig 2>/dev/null || rm -rf /root/.gitconfig
+              fi
+              # Symlink ~/.gitconfig → persistent dotfiles
+              if [ ! -L /root/.gitconfig ]; then
+                ln -sf "$DOTFILES/gitconfig" /root/.gitconfig
+                log "Symlinked ~/.gitconfig → $DOTFILES/gitconfig"
+              fi
+              # Seed defaults on first deploy
+              if [ ! -f "$DOTFILES/gitconfig" ]; then
                 log "First deploy — seeding global git config"
                 git config --global user.email "opencode@local"
                 git config --global user.name "OpenCode"
@@ -118,6 +130,11 @@ app-template:
               APK_CACHE=/root/.config/opencode/apk-cache
               apk add --no-cache --cache-dir "$APK_CACHE" \
                 gcompat git bash curl openssh-client github-cli
+              # Symlink ~/.gitconfig to the persistent dotfiles dir
+              if [ -d /root/.gitconfig ] && [ ! -L /root/.gitconfig ]; then
+                rmdir /root/.gitconfig 2>/dev/null || rm -rf /root/.gitconfig
+              fi
+              [ ! -L /root/.gitconfig ] && ln -sf /persistent-dotfiles/gitconfig /root/.gitconfig
               exec opencode web --port 4096 --hostname 0.0.0.0 --mdns
           envFrom:
             - secretRef:
@@ -235,9 +252,9 @@ app-template:
     #   config/           → ~/.config/opencode/ (auth.json, global opencode.json)
     #   share/            → ~/.local/share/opencode/ (conversation data)
     #   workspace/        → /workspace (git repos, agents, skills, project files)
-    #   dotfiles/gitconfig → ~/.gitconfig (global git user.name, user.email, credential helpers)
-    #   dotfiles/ssh/     → ~/.ssh/ (SSH keys, known_hosts)
-    #   dotfiles/gh/      → ~/.config/gh/ (GitHub CLI auth tokens)
+    #   dotfiles/         → /persistent-dotfiles/ (gitconfig file, symlinked from ~/.gitconfig)
+    #   dotfiles-ssh/     → ~/.ssh/ (SSH keys, known_hosts)
+    #   dotfiles-gh/      → ~/.config/gh/ (GitHub CLI auth tokens)
     data:
       enabled: true
       type: persistentVolumeClaim
@@ -253,12 +270,12 @@ app-template:
               subPath: share
             - path: /workspace
               subPath: workspace
-            - path: /root/.gitconfig
-              subPath: dotfiles/gitconfig
+            - path: /persistent-dotfiles
+              subPath: dotfiles
             - path: /root/.ssh
-              subPath: dotfiles/ssh
+              subPath: dotfiles-ssh
             - path: /root/.config/gh
-              subPath: dotfiles/gh
+              subPath: dotfiles-gh
           main:
             - path: /root/.config/opencode
               subPath: config
@@ -266,9 +283,9 @@ app-template:
               subPath: share
             - path: /workspace
               subPath: workspace
-            - path: /root/.gitconfig
-              subPath: dotfiles/gitconfig
+            - path: /persistent-dotfiles
+              subPath: dotfiles
             - path: /root/.ssh
-              subPath: dotfiles/ssh
+              subPath: dotfiles-ssh
             - path: /root/.config/gh
-              subPath: dotfiles/gh
+              subPath: dotfiles-gh

--- a/kube/opencode/values.yaml
+++ b/kube/opencode/values.yaml
@@ -36,6 +36,9 @@ app-template:
 
               log "Starting initialization"
               mkdir -p /root/.config/opencode /root/.local/share/opencode /workspace
+              mkdir -p /root/.ssh
+              chmod 700 /root/.ssh
+              mkdir -p /root/.config/gh
 
               # ── System packages ──────────────────────────────────────
               # Alpine image lacks git/bash and needs a glibc shim for
@@ -44,8 +47,8 @@ app-template:
               mkdir -p "$APK_CACHE"
               log "Installing system packages (cached at $APK_CACHE)"
               apk add --no-cache --cache-dir "$APK_CACHE" \
-                gcompat git bash curl openssh-client
-              log "Packages installed"
+                gcompat git bash curl openssh-client github-cli
+              log "Packages installed (including gh CLI)"
 
               # ── glibc shim ───────────────────────────────────────────
               # Bun extracts a PTY native .so compiled against glibc.
@@ -75,13 +78,24 @@ app-template:
                 log "Existing config found — preserving runtime config"
               fi
 
+              # ── Global Git config ────────────────────────────────────
+              # ~/.gitconfig is on a persistent mount, so this only runs
+              # on first deploy. User can change these at runtime and
+              # they will survive pod restarts.
+              if [ ! -f /root/.gitconfig ]; then
+                log "First deploy — seeding global git config"
+                git config --global user.email "opencode@local"
+                git config --global user.name "OpenCode"
+                git config --global init.defaultBranch main
+              else
+                log "Existing global git config found — preserving"
+              fi
+
               # ── Workspace ────────────────────────────────────────────
               if [ ! -d /workspace/.git ]; then
                 log "Initializing workspace as git repo"
                 cd /workspace
                 git init -b main
-                git config user.email "opencode@local"
-                git config user.name "OpenCode"
                 echo "# OpenCode Workspace" > README.md
                 git add . && git commit -m "init workspace"
               else
@@ -103,7 +117,7 @@ app-template:
             - |
               APK_CACHE=/root/.config/opencode/apk-cache
               apk add --no-cache --cache-dir "$APK_CACHE" \
-                gcompat git bash curl openssh-client
+                gcompat git bash curl openssh-client github-cli
               exec opencode web --port 4096 --hostname 0.0.0.0 --mdns
           envFrom:
             - secretRef:
@@ -218,8 +232,12 @@ app-template:
               readOnly: true
 
     # Main data PVC — holds all persistent state:
-    #   config/  → ~/.config/opencode/ (auth.json, global opencode.json)
-    #   workspace/ → /workspace (git repos, agents, skills, project files)
+    #   config/           → ~/.config/opencode/ (auth.json, global opencode.json)
+    #   share/            → ~/.local/share/opencode/ (conversation data)
+    #   workspace/        → /workspace (git repos, agents, skills, project files)
+    #   dotfiles/gitconfig → ~/.gitconfig (global git user.name, user.email, credential helpers)
+    #   dotfiles/ssh/     → ~/.ssh/ (SSH keys, known_hosts)
+    #   dotfiles/gh/      → ~/.config/gh/ (GitHub CLI auth tokens)
     data:
       enabled: true
       type: persistentVolumeClaim
@@ -235,6 +253,12 @@ app-template:
               subPath: share
             - path: /workspace
               subPath: workspace
+            - path: /root/.gitconfig
+              subPath: dotfiles/gitconfig
+            - path: /root/.ssh
+              subPath: dotfiles/ssh
+            - path: /root/.config/gh
+              subPath: dotfiles/gh
           main:
             - path: /root/.config/opencode
               subPath: config
@@ -242,5 +266,9 @@ app-template:
               subPath: share
             - path: /workspace
               subPath: workspace
-
-
+            - path: /root/.gitconfig
+              subPath: dotfiles/gitconfig
+            - path: /root/.ssh
+              subPath: dotfiles/ssh
+            - path: /root/.config/gh
+              subPath: dotfiles/gh


### PR DESCRIPTION
- Add PVC subPath mounts for ~/.gitconfig, ~/.ssh/, and ~/.config/gh/
- Install github-cli (gh) package in init and main containers
- Seed global git config on first deploy instead of per-repo local config
- Update PVC documentation comments with new mount mappings
