### PR TITLE
fix(postgresql): increase memory limits to prevent OOM kills

### DIFF
--- a/kube/postgresql/postgresql-statefulset.yaml
+++ b/kube/postgresql/postgresql-statefulset.yaml
@@ -32,10 +32,10 @@ spec:
               value: /var/lib/postgresql/data/pgdata
           resources:
             requests:
-              memory: "256Mi"
+              memory: "512Mi"
               cpu: "100m"
             limits:
-              memory: "1Gi"
+              memory: "2Gi"
               cpu: "500m"
           volumeMounts:
             - name: postgresql-data
@@ -46,17 +46,17 @@ spec:
                 - pg_isready
                 - -U
                 - postgres
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 3
+            failureThreshold: 6
           readinessProbe:
             exec:
               command:
                 - pg_isready
                 - -U
                 - postgres
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 3


### PR DESCRIPTION
PostgreSQL was being OOM-killed (exit code 137) with 107 restarts in 83
days, causing cascading connection failures in fwm-bot and egroup-bot.

- Increase memory request from 256Mi to 512Mi
- Increase memory limit from 1Gi to 2Gi
- Increase liveness probe initialDelaySeconds from 30s to 60s
- Increase liveness probe failureThreshold from 3 to 6
- Increase readiness probe initialDelaySeconds from 5s to 10s
