### PR TITLE
fix(openclaw): persist gogcli binary and alias

### DIFF
--- a/kube/openclaw/values-common.yaml
+++ b/kube/openclaw/values-common.yaml
@@ -91,9 +91,14 @@ app-template:
               # Add brew to path for this session
               eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 
-              if ! command -v gogcli >/dev/null; then
-                log "Installing gogcli..."
-                brew install gogcli
+              if ! command -v gog >/dev/null; then
+                log "Installing gogcli formula..."
+                brew install openclaw/tap/gogcli
+              fi
+
+              if [ -x /home/linuxbrew/.linuxbrew/bin/gog ] && [ ! -e /home/linuxbrew/.linuxbrew/bin/gogcli ]; then
+                log "Creating gogcli compatibility symlink"
+                ln -sf /home/linuxbrew/.linuxbrew/bin/gog /home/linuxbrew/.linuxbrew/bin/gogcli
               fi
 
               # Original skill installation logic


### PR DESCRIPTION
## Summary
- check for the actual installed gog binary instead of gogcli
- install openclaw/tap/gogcli during init when the binary is missing
- create a persistent gogcli symlink in the Linuxbrew PVC so both command names resolve after restart

## Verification
- redeployed with source sensitive/secrets.sh && ./deploy/08-deploy-openclaw.sh
- confirmed init-skills created the compatibility symlink
- confirmed /home/linuxbrew/.linuxbrew/bin/gog and /home/linuxbrew/.linuxbrew/bin/gogcli exist in the running pod
- confirmed kubectl exec -n openclaw <pod> -c main -- sh -c 'command -v gog; command -v gogcli' resolves both commands
- confirmed kubectl exec -n openclaw <pod> -c main -- /home/linuxbrew/.linuxbrew/bin/gog --help runs successfully
